### PR TITLE
Search extension

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,11 +38,12 @@ before_script:
 script:
   - cd src; cl -e '(ql:quickload :ttt)
                    (ql:quickload :uiop)
-                   (ql:quickload :lisp-unit)
                    (in-package :ttt)
+                   ; Original TTT tests
                    (load-tests-all)
                    (compile-tests)
                    (run-tests)
+                   ; Additional unit tests
                    (loop for test-file in (directory "test/*.lisp")
                          do (load test-file))
                    (format t "Running unit tests...")

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ before_script:
 script:
   - cd src; cl -e '(ql:quickload :ttt)
                    (ql:quickload :uiop)
+                   (ql:quickload :lisp-unit)
                    (in-package :ttt)
                    (load-tests-all)
                    (compile-tests)

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,12 +39,11 @@ script:
   - cd src; cl -e '(ql:quickload :ttt)
                    (ql:quickload :uiop)
                    (in-package :ttt)
-                   ; Original TTT tests
                    (load-tests-all)
+                   (format t "Original TTT tests...~%") 
                    (compile-tests)
                    (run-tests)
-                   ; Additional unit tests
+                   (format t "New unit tests...~%") (format t "Original TTT tests...~%")
                    (loop for test-file in (directory "test/*.lisp")
                          do (load test-file))
-                   (format t "Running unit tests...")
                    (lisp-unit:run-tests)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,4 +43,7 @@ script:
                    (load-tests-all)
                    (compile-tests)
                    (run-tests)
-                   (load "run-unit-tests")'
+                   (loop for test-file in (directory "test/*.lisp")
+                         do (load test-file))
+                   (format t "Running unit tests...")
+                   (lisp-unit:run-tests)'

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,9 +36,10 @@ before_script:
   - echo "(defsystem :dummy-cl-travis-system)" > ~/lisp/dummy-cl-travis-system.asd
 
 script:
-  - cl -e '(ql:quickload :ttt)
-           (ql:quickload :uiop)
-           (in-package :ttt)
-           (load-tests-all)
-           (compile-tests)
-           (run-tests)'
+  - cd src; cl -e '(ql:quickload :ttt)
+                   (ql:quickload :uiop)
+                   (in-package :ttt)
+                   (load-tests-all)
+                   (compile-tests)
+                   (run-tests)
+                   (load "run-unit-tests")'

--- a/src/expressions.lisp
+++ b/src/expressions.lisp
@@ -2,26 +2,51 @@
 ;; These functions are used only by build-pattern and build-tree
 ;; to construct the respective objects from expressions.
 
+;(defun patt-expr-neg-args (expression)
+;  "Given patt = '(op X1 X1 ... Xm ~ Y1 Y2 ... Yn) return '(Y1 Y2 ... Yn)"
+;  (declare (type list expression))
+;  (let* ((pkg (symbol-package (car expression)))
+;         (til (if (eq pkg (find-package "COMMON-LISP"))
+;                (intern "~")
+;                (intern "~" pkg)))
+;         (pos (position til expression)))
+;    (if pos (subseq expression (1+ pos)))))
+;
 (defun patt-expr-neg-args (expression)
   "Given patt = '(op X1 X1 ... Xm ~ Y1 Y2 ... Yn) return '(Y1 Y2 ... Yn)"
   (declare (type list expression))
-  (let* ((pkg (symbol-package (car expression)))
-         (til (if (eq pkg (find-package "COMMON-LISP"))
-                (intern "~")
-                (intern "~" pkg)))
-         (pos (position til expression)))
+  ; intern any atomic symbols so it matches with '~ declared here.
+  (let* ((symbol-interned 
+           (mapcar #'(lambda (x) (if (symbolp x) (intern (symbol-name x) :ttt) x))
+                   expression))
+         ;(pkg (symbol-package (car expression)))
+         ;(til (if (eq pkg (find-package "COMMON-LISP"))
+         ;       (intern "~")
+         ;       (intern "~" pkg)))
+         (pos (position '~ symbol-interned)))
+    ; Return original package symbols.
     (if pos (subseq expression (1+ pos)))))
 
+;(defun patt-expr-pos-args (expression)
+;  "Given patt = '(op X1 X2 ... Xm ~ Y1 Y2 ... Yn) return '(X1 X2 ... Xm)"
+;  (declare (type list expression))
+;  (if (and (get-op (car expression))
+;           (op-requires-args? (get-op (car expression))))
+;      (let* ((pkg (symbol-package (car expression)))
+;             (til (if (eq pkg (find-package "COMMON-LISP"))
+;                    (intern "~")
+;                    (intern "~" pkg))))
+;        (subseq expression 1 (position til expression)))
+;      expression))
 (defun patt-expr-pos-args (expression)
   "Given patt = '(op X1 X2 ... Xm ~ Y1 Y2 ... Yn) return '(X1 X2 ... Xm)"
   (declare (type list expression))
   (if (and (get-op (car expression))
            (op-requires-args? (get-op (car expression))))
-      (let* ((pkg (symbol-package (car expression)))
-             (til (if (eq pkg (find-package "COMMON-LISP"))
-                    (intern "~")
-                    (intern "~" pkg))))
-        (subseq expression 1 (position til expression)))
+      (let ((symbol-interned
+               (mapcar #'(lambda (x) (if (symbolp x) (intern (symbol-name x) :ttt) x))
+                       expression)))
+        (subseq expression 1 (position '~ symbol-interned)))
       expression))
 
 (declaim (ftype (function ((or list symbol number)) fixnum) expr-height))

--- a/src/expressions.lisp
+++ b/src/expressions.lisp
@@ -2,16 +2,6 @@
 ;; These functions are used only by build-pattern and build-tree
 ;; to construct the respective objects from expressions.
 
-;(defun patt-expr-neg-args (expression)
-;  "Given patt = '(op X1 X1 ... Xm ~ Y1 Y2 ... Yn) return '(Y1 Y2 ... Yn)"
-;  (declare (type list expression))
-;  (let* ((pkg (symbol-package (car expression)))
-;         (til (if (eq pkg (find-package "COMMON-LISP"))
-;                (intern "~")
-;                (intern "~" pkg)))
-;         (pos (position til expression)))
-;    (if pos (subseq expression (1+ pos)))))
-;
 (defun patt-expr-neg-args (expression)
   "Given patt = '(op X1 X1 ... Xm ~ Y1 Y2 ... Yn) return '(Y1 Y2 ... Yn)"
   (declare (type list expression))
@@ -19,25 +9,10 @@
   (let* ((symbol-interned 
            (mapcar #'(lambda (x) (if (symbolp x) (intern (symbol-name x) :ttt) x))
                    expression))
-         ;(pkg (symbol-package (car expression)))
-         ;(til (if (eq pkg (find-package "COMMON-LISP"))
-         ;       (intern "~")
-         ;       (intern "~" pkg)))
          (pos (position '~ symbol-interned)))
     ; Return original package symbols.
     (if pos (subseq expression (1+ pos)))))
 
-;(defun patt-expr-pos-args (expression)
-;  "Given patt = '(op X1 X2 ... Xm ~ Y1 Y2 ... Yn) return '(X1 X2 ... Xm)"
-;  (declare (type list expression))
-;  (if (and (get-op (car expression))
-;           (op-requires-args? (get-op (car expression))))
-;      (let* ((pkg (symbol-package (car expression)))
-;             (til (if (eq pkg (find-package "COMMON-LISP"))
-;                    (intern "~")
-;                    (intern "~" pkg))))
-;        (subseq expression 1 (position til expression)))
-;      expression))
 (defun patt-expr-pos-args (expression)
   "Given patt = '(op X1 X2 ... Xm ~ Y1 Y2 ... Yn) return '(X1 X2 ... Xm)"
   (declare (type list expression))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -1,6 +1,6 @@
 (defpackage ttt
   (:documentation "the TTT (template to template transduction) package!")
-  (:use :common-lisp)
+  (:use :cl :lisp-unit)
   (:export :match-expr
            :apply-rules
            :apply-rule

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -1,6 +1,7 @@
 (defpackage ttt
   (:documentation "the TTT (template to template transduction) package!")
   (:use :cl :lisp-unit)
+  (:shadow :run-tests)
   (:export :match-expr
            :apply-rules
            :apply-rule

--- a/src/patterns.lisp
+++ b/src/patterns.lisp
@@ -161,3 +161,16 @@
             (setf b (deep-match-brute pattern c ))
             (if b (return b)))))))
 
+(defun deepest-matches (pattern tree)
+  "Matched a compiled pattern against a compiled tree object,
+  each subtree is tested and a list of all results are returned."
+  ; TODO(gene): match a brute vs non-brute version like above
+  (let ((b (match pattern (list tree) t )))
+    (cond
+      ((and b (leaf? tree)) (list b))
+      ((leaf? tree) nil)
+      (t 
+        (let ((recres (mapcar #'(lambda (c) (deepest-matches pattern c))
+                              (children tree))))
+          (apply #'append (if b (cons (list b) recres) recres)))))))
+

--- a/src/run-unit-tests.lisp
+++ b/src/run-unit-tests.lisp
@@ -1,0 +1,6 @@
+;; Runs the unit tests defined through lisp-unit in test/
+(load "load")
+(loop for test-file in (directory "test/*.lisp")
+      do (load test-file))
+(in-package :ttt)
+(lisp-unit:run-tests)

--- a/src/run-unit-tests.lisp
+++ b/src/run-unit-tests.lisp
@@ -1,5 +1,6 @@
 ;; Runs the unit tests defined through lisp-unit in test/
-(load "load")
+;(load "load")
+(ql:quickload :ttt)
 (loop for test-file in (directory "test/*.lisp")
       do (load test-file))
 (in-package :ttt)

--- a/src/test/deepest-match.lisp
+++ b/src/test/deepest-match.lisp
@@ -50,6 +50,7 @@
                                                  (ON.P (THE.D (|Starbucks| BLOCK.N))))))))))) [?]))
 
          inf-rule)
+    (declare (ignore bad-inf))
     (defun local-conj! (pat)
       (cond
         ((atom pat) pat)

--- a/src/test/deepest-match.lisp
+++ b/src/test/deepest-match.lisp
@@ -1,0 +1,68 @@
+;;; Gene Louis Kim, 4-6-2020
+;;; Unit tests for verifying more exhaustive fix for apply.
+
+(in-package :ttt)
+
+(setq *print-failures* t)
+(setq *print-errors* t)
+(setq *print-summary* t)
+(setq *summarize-results* t)
+
+(define-test basic-deepest-match
+  "Basic tests for deepest match."
+  (:tag :deepest-match)
+  (let* ((sentence
+           '((SUB (AT.P (WHAT.D PLACE.N)) 
+                 ((THE.D (|Target| BLOCK.N)) 
+                  ((PAST BE.V) [*H] 
+                   (ADV-E (BEFORE.P (KE (IT.PRO ((PAST BE.V)
+                                                 (ON.P (THE.D (|Starbucks| BLOCK.N))))))))))) [?]))
+         (term-pattern '(!1 (what.d place.n)
+                           |Target|
+                           (the.d (|Target| block.n))
+                           it.pro
+                           |Starbucks|
+                           (the.d (|Starbucks| block.n))
+                           (ke (it.pro ((past be.v) (on.p (the.d (|Starbucks| block.n))))))))
+         (pred-pattern '(!2 (at.p (what.d place.n))
+                           place.n
+                           block.n
+                           (|Target| block.n)
+                           be.v
+                           (past be.v)
+                           (|Starbucks| block.n)
+                           (on.p (the.d (|Starbucks| block.n)))
+                           ((past be.v) (on.p (the.d (|Starbucks| block.n))))
+                           (before.p (ke (it.pro ((past be.v) (on.p (the.d (|Starbucks| block.n)))))))
+                           ((past be.v) [*h]
+                                        (adv-e (before.p (ke (it.pro ((past be.v) (on.p (the.d (|Starbucks| block.n)))))))))))
+         (bad-inf
+           '((SUB (AT.P (WHAT.D PLACE.N)) 
+                 ((THE.D (|Target| BLOCK.N)) 
+                  (WAS.V [*H] 
+                   (ADV-E (BEFORE.P (KE (IT.PRO ((PAST BE.V)
+                                                 (ON.P (THE.D (|Starbucks| BLOCK.N))))))))))) [?]))
+         (good-inf
+           '((SUB (AT.P (WHAT.D PLACE.N)) 
+                 ((THE.D (|Target| BLOCK.N)) 
+                  (WAS.V [*H] 
+                   (ADV-E (BEFORE.P (KE (IT.PRO (WAS.V
+                                                 (ON.P (THE.D (|Starbucks| BLOCK.N))))))))))) [?]))
+
+         inf-rule)
+    (defun local-conj! (pat)
+      (cond
+        ((atom pat) pat)
+        ((equal pat '(past be.v)) 'was.v)
+        (t (mapcar #'local-conj! pat))))
+
+    (setf inf-rule
+          (list '/
+                (list term-pattern pred-pattern)
+                '(!1 (local-conj! !2))))
+
+    (assert-false (equal good-inf (apply-rules (list inf-rule) sentence :max-n 1000
+                                           :rule-order :slow-forward)))
+    (assert-equal good-inf (apply-rules (list inf-rule) sentence :max-n 1000
+                                           :rule-order :slow-forward :rule-depth :deepest))))
+

--- a/src/transductions.lisp
+++ b/src/transductions.lisp
@@ -45,18 +45,33 @@
   (setf (compiled? patt) t)
   patt)
 
+(defun get-matches (pattern tree rule-depth)
+  "Runes the compiled pattern agains a compiled tree object with the given
+  rule-depth option. This is a helper function for apply-rule and apply-rules
+  and does not check any of the inputs.
+
+  Returns a list of matched subtrees."
+  (case rule-depth
+    (:shallow (list (match pattern (list tree) t)))
+    (:deepest (deepest-matches pattern tree))
+    (:default (list (deep-match pattern tree)))
+    (otherwise (error "Unknown rule-depth option: ~s~%" rule-depth))))
+
 (defun apply-rules (rules tree-expr &key
                                       (rule-order :slow-forward)
                                       (trace nil)
                                       (shallow nil)
                                       (deepest nil)
-                                      (max-n most-positive-fixnum))
+                                      (max-n most-positive-fixnum)
+                                      (rule-depth :default))
   "Apply each of the rules in list rules to a tree expression
    until each rule is no longer applicable. The rules list is only
    processed once. Returns a new tree expression.
 
-   shallow    limits rule applications to root of tree
+   shallow    limits rule applications to root of tree (alternative to using
+              :rule-depth :shallow)
    deepest    allows multiple recursive matches into the tree at each step
+              (alternative to using :rule-depth :deepest)
    max-n      limits the maximum number of edits to a tree
    trace      when t, displays debugging info to stdout
               otherwise, when non-nil write debugging info to file
@@ -75,11 +90,32 @@
                      is applicable, repeat until no rules are applicable
                      the rule list may be processed multiple times
    :fast-forward   - apply each rule at most once, in order, repeating
-                     the list until convergence"
+                     the list until convergence
+
+   rule-depth
+   :default   Rule application can occur at any depth, but only one match is
+              returned at each step.
+   :shallow   Rule application can only occur at the root of the tree.
+   :deepest   Rule application can occur at any depth, and all matches are
+              returned at each step. Setting a rule-depth value is recommended
+              when using this option to enable reasonable runtimes. This rule
+              may only be used with rule-order :slow-forward. Behavior is
+              undefined for other rule-order options."
 
   (declare (type list rules))
 
-  (let ((tr (if shallow
+  (when (not (member rule-depth '(:default :shallow :deepest)))
+    (error "Invalid rule-depth option (~s). Must be one of '(:default :shallow :deepest)."
+           rule-depth))
+  (when (not (member rule-order '(:slow-forward :earliest-first :fast-forward)))
+    (error "Invalid rule-order option (~s). Must be one of '(:slow-forward :earliest-first :fast-forward)."
+           rule-depth))
+  (when (and (eql rule-depth :default) shallow)
+    (setf rule-depth :shallow))
+  (when (and (eql rule-depth :default) deepest)
+    (setf rule-depth :deepest))
+
+  (let ((tr (if (eql rule-depth :shallow)
                 (build-tree tree-expr :index-subtrees nil)
                 (build-tree tree-expr :index-subtrees t)))
         (trace-file (if (or (eq trace t) (null trace))
@@ -95,11 +131,11 @@
     (declare (type fixnum n max-n)
              (type stream trace-file))
 
-  (if (> *ttt-debug-level* 0)
-    (progn
-      (format t "===apply-rules===~%")
-      (format t "rules:     ~s~%" rules)
-      (format t "tree-expr: ~s~%~%" tree-expr)))
+    (when (> *ttt-debug-level* 0)
+      (progn
+        (format t "===apply-rules===~%")
+        (format t "rules:     ~s~%" rules)
+        (format t "tree-expr: ~s~%~%" tree-expr)))
 
     (case rule-order
       (:slow-forward
@@ -108,19 +144,10 @@
             ; TODO(gene): run the TTT tests after this change to verify correctness
             ; TODO(gene): probable memoize the deepest match so that when we come across the same thing we don't re-compute
             (dolist (r compiled-rules)
-              (let ((bs (cond
-                          (shallow (list (match r (list tr) t)))
-                          (deepest (deepest-matches r tr)) ; TODO(gene): come up with better flag and generalize this to all other applicable functions
-                          (t (list (deep-match r tr)))))
+              (let ((bs (get-matches r tr rule-depth))
                     (converged2 nil)
                     b)
-                (if (equal bs '(nil)) (setf bs nil))
-                ;(format t "bs: ~s~%" bs)
-                ;(when (not (null b))
-                ;  (format t "#HASH{~{~{(~a : ~a)~}~^ ~}}"
-                ;          (loop for key being the hash-keys of b
-                ;                using (hash-value value)
-                ;                collect (list key value))))
+                (when (equal bs '(nil)) (setf bs nil))
                 (loop while (and (not converged2) bs (< n max-n)) do
                      (setf b (car bs))
                      (setf bs (cdr bs))
@@ -131,14 +158,11 @@
                                  prev
                                  (to-expr tr)))
                      (incf n)
-                     (if (and (equal prev (to-expr tr)) (not deepest))
+                     (if (and (equal prev (to-expr tr))
+                              (not (eql rule-depth :deepest)))
                          (setf converged2 t)
                          (setf bs
-                               (append bs 
-                                       (cond 
-                                         (shallow (match r (list tr) t))
-                                         (deepest (deepest-matches r tr))  
-                                         (t (deep-match r tr))))
+                               (append bs (get-matches r tr rule-depth))
                                prev (to-expr tr)
                                converged nil)))
                 ))))
@@ -147,9 +171,8 @@
        (loop while (not converged) do
             (setf converged t)
             (dolist (r compiled-rules)
-              (let ((b (if shallow
-                           (match r (list tr) t)
-                           (deep-match r tr))))
+              (let* ((bs (get-matches r tr rule-depth))
+                     (b (car bs)))
                 (when b
                   (setf prev (to-expr tr))
                   (setf tr (do-transduction tr (get-binding '/ b) b))
@@ -167,9 +190,8 @@
        (loop while (not converged) do
             (setf converged t)
             (dolist (r compiled-rules)
-              (let ((b (if shallow
-                           (match r (list tr) t)
-                           (deep-match r tr))))
+              (let* ((bs (get-matches r tr rule-depth))
+                     (b (car bs)))
                 (when b
                   (setf prev (to-expr tr))
                   (setf tr (do-transduction tr (get-binding '/ b) b))
@@ -190,7 +212,8 @@
 (defun apply-rule (rule-expr tree-expr &key
                                          (shallow nil)
                                          (trace nil)
-                                         (max-n most-positive-fixnum))
+                                         (max-n most-positive-fixnum)
+                                         (rule-depth :default))
   "Apply a single rule to a tree expression until converged.
    Returns a new tree expression.
 
@@ -202,9 +225,19 @@
               format is (one triple of lines per transduction):
               <tree before transduction>
               <tree after transduction>
-              <blank line>"
+              <blank line>
+
+   rule-depth
+   :default   Rule application can occur at any depth, but only one match is
+              returned at each step.
+   :shallow   Rule application can only occur at the root of the tree.
+   :deepest   Rule application can occur at any depth, and all matches are
+              returned at each step. Setting a rule-depth value is recommended
+              when using this option to enable reasonable runtimes."
 
   (declare (type list rule-expr))
+  (when (and (eql rule-depth :default) shallow)
+    (setf rule-depth :shallow))
   (let ((tr (build-tree tree-expr :index-subtrees t))
         (compiled-rule (build-pattern rule-expr))
         (trace-file (if (or (eq trace t) (null trace))
@@ -218,20 +251,17 @@
         (n 0))
     (declare (type fixnum n max-n)
              (type stream trace-file))
-    (let ((b
-           (if shallow
-               (match compiled-rule (list tr) t)
-               (deep-match compiled-rule tr))))
-      (loop while (and (not converged) b (< n max-n)) do
+    (let* ((bs (get-matches compiled-rule tr rule-depth))
+           (b (car bs)))
+      (loop while (and (not converged) bs (< n max-n)) do
            (setf tr (do-transduction tr (get-binding '/ b) b))
            (if trace (format trace-file "~a~%~a~%~%" prev (to-expr tr)))
            (incf n)
-           (if (equal prev (to-expr tr))
+           (if (and (equal prev (to-expr tr))
+                    (not (eql rule-depth :deepest)))
                (setf converged t)
-               (setf b
-                     (if shallow
-                         (match compiled-rule (list tr) t)
-                         (deep-match compiled-rule tr))
+               (setf bs
+                     (append bs (get-matches compiled-rule tr rule-depth))
                      prev (to-expr tr)))))
     (if (and trace-file (not (eq trace-file *standard-output*)))
       (close trace-file))

--- a/src/transductions.lisp
+++ b/src/transductions.lisp
@@ -162,7 +162,7 @@
                               (not (eql rule-depth :deepest)))
                          (setf converged2 t)
                          (setf bs
-                               (get-matches r tr rule-depth)
+                               (append bs (get-matches r tr rule-depth))
                                prev (to-expr tr)
                                converged nil)))
                 ))))
@@ -252,8 +252,10 @@
     (declare (type fixnum n max-n)
              (type stream trace-file))
     (let* ((bs (get-matches compiled-rule tr rule-depth))
-           (b (car bs)))
+           b)
       (loop while (and (not converged) bs b (< n max-n)) do
+           (setf b (car bs))
+           (setf bs (cdr bs))
            (setf tr (do-transduction tr (get-binding '/ b) b))
            (if trace (format trace-file "~a~%~a~%~%" prev (to-expr tr)))
            (incf n)
@@ -261,7 +263,7 @@
                     (not (eql rule-depth :deepest)))
                (setf converged t)
                (setf bs
-                     (get-matches compiled-rule tr rule-depth)
+                     (append bs (get-matches compiled-rule tr rule-depth))
                      prev (to-expr tr)))))
     (if (and trace-file (not (eq trace-file *standard-output*)))
       (close trace-file))

--- a/src/ttt.asd
+++ b/src/ttt.asd
@@ -1,5 +1,6 @@
 (defpackage :ttt)
 (asdf:defsystem :ttt
+    :depends-on (:lisp-unit)
     :components ((:file "package")
                  (:file "operators")
                  (:file "expressions")
@@ -17,7 +18,7 @@
                  (:file "predicates")
                  (:file "template-construction")
                  (:file "transductions")
-                 (:file "tests")
+                 ;(:file "tests")
                  (:file "util")
                  (:file "process-tb")
                  (:file "search-tb"))

--- a/src/ttt.asd
+++ b/src/ttt.asd
@@ -18,7 +18,7 @@
                  (:file "predicates")
                  (:file "template-construction")
                  (:file "transductions")
-                 ;(:file "tests")
+                 (:file "tests") ; TODO:  ; move this to a separate testing package.move this to a separate testing package.
                  (:file "util")
                  (:file "process-tb")
                  (:file "search-tb"))


### PR DESCRIPTION
Extending the `apply-rule` and `apply-rules` function APIs to include a `rule-depth` option which has `:shallow`, `:default`, and `:deepest`. `deepest` is a new feature that exhaustively searches through every match instead of the first one at each application step and only converges when all matches have been address (rather than when there is on change to the tree).