### PR TITLE
Fixed negations from external packages.

### DIFF
--- a/src/expressions.lisp
+++ b/src/expressions.lisp
@@ -5,11 +5,12 @@
 (defun patt-expr-neg-args (expression)
   "Given patt = '(op X1 X1 ... Xm ~ Y1 Y2 ... Yn) return '(Y1 Y2 ... Yn)"
   (declare (type list expression))
-  (let* ((pkg (symbol-package (car expression)))
-         (til (if (eq pkg (find-package "COMMON-LISP"))
-                (intern "~")
-                (intern "~" pkg)))
-         (pos (position til expression)))
+  ; intern any atomic symbols so it matches with '~ declared here.
+  (let* ((symbol-interned 
+           (mapcar #'(lambda (x) (if (symbolp x) (intern (symbol-name x) :ttt) x))
+                   expression))
+         (pos (position '~ symbol-interned)))
+    ; Return original package symbols.
     (if pos (subseq expression (1+ pos)))))
 
 (defun patt-expr-pos-args (expression)
@@ -17,11 +18,10 @@
   (declare (type list expression))
   (if (and (get-op (car expression))
            (op-requires-args? (get-op (car expression))))
-      (let* ((pkg (symbol-package (car expression)))
-             (til (if (eq pkg (find-package "COMMON-LISP"))
-                    (intern "~")
-                    (intern "~" pkg))))
-        (subseq expression 1 (position til expression)))
+      (let ((symbol-interned
+               (mapcar #'(lambda (x) (if (symbolp x) (intern (symbol-name x) :ttt) x))
+                       expression)))
+        (subseq expression 1 (position '~ symbol-interned)))
       expression))
 
 (declaim (ftype (function ((or list symbol number)) fixnum) expr-height))


### PR DESCRIPTION
Fixed negation (~) patterns with symbols from external packages. Before it failed in cases where the operator has not an external symbol (rather a universal one or interned elsewhere). Now the interning is always done to the TTT package and the symbol is directly compared. This is just in the recognition step, so the output symbols are not affected in anyway except in computing the decision boundary of the negation.